### PR TITLE
gnuradio: Update version to 3.8.3, fix CMake flags

### DIFF
--- a/recipes-core/gnuradio/gnuradio_git.bb
+++ b/recipes-core/gnuradio/gnuradio_git.bb
@@ -219,7 +219,7 @@ python populate_packages_prepend() {
 }
 
 #PV = "3.8.0+git${SRCPV}"
-PV = "3.8.0.0"
+PV = "3.8.3.0"
 
 FILESPATHPKG_prepend = "gnuradio-git:"
 
@@ -238,12 +238,10 @@ S="${WORKDIR}/git"
 
 EXTRA_OECMAKE = "\
                  -DGR_PYTHON_DIR=${PYTHON_SITEPACKAGES_DIR} \
-                 -DENABLE_GR_ATSC=FALSE \
-                 -DENABLE_GR_FCD=OFF \
-                 -DENABLE_GR_WXGUI=OFF \
                  -DENABLE_GR_VIDEO_SDL=OFF \
                  -DENABLE_GR_DTV=OFF \
-                 -DENABLE_SPHINX=OFF -DENABLE_DOXYGEN=OFF \
+                 -DENABLE_SPHINX=OFF \
+                 -DENABLE_DOXYGEN=OFF \
                  -DENABLE_ORC=OFF \
                  -DENABLE_GR_VOCODER=OFF \
                  -DENABLE_INTERNAL_VOLK=OFF \


### PR DESCRIPTION
- 3.8.3.0 is the latest stable 3.8 release as of today
- FCD, WXGUI, and ATSC in-tree components were removed in 3.8

Signed-off-by: Martin Braun <martin.braun@ettus.com>